### PR TITLE
Creating tasks: foo bar examples

### DIFF
--- a/Creating-tasks.md
+++ b/Creating-tasks.md
@@ -114,7 +114,7 @@ grunt.registerTask('foo', 'My "foo" task.', function(a, b) {
 // Usage:
 // grunt foo
 //   logs: "foo", undefined, undefined
-// grunt foo foo:bar
+// grunt foo:bar
 //   logs: "foo", "bar", undefined
 // grunt foo:bar:baz
 //   logs: "foo", "bar", "baz"

--- a/Creating-tasks.md
+++ b/Creating-tasks.md
@@ -169,6 +169,8 @@ grunt.registerTask('bar', 'My "bar" task.', function() {
 // Usage:
 // grunt foo bar
 //   doesn't log, because foo failed.
+//   ***Note: This is an example of space-separated sequential commands,
+//   (similar to executing two lines of code: `grunt foo` then `grunt bar`)
 // grunt bar
 //   doesn't log, because foo never ran.
 ```


### PR DESCRIPTION
* Corrected error with `grunt foo foo:bar` — Should be `grunt foo:bar`
* Added comment explaining space-separated sequential commands
  * This is because sequential commands haven't been explained on this page, making the code less easily understood

Merging these commits will allow your [pull request](https://github.com/gruntjs/grunt-docs/pull/132) to be accepted :)